### PR TITLE
Mirror `node-runtime` types and test for compatibility

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,23 +18,18 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-# ink_core = { git = "https://github.com/paritytech/ink/", branch = "aj-runtime-types", package = "ink_core" }
-ink_core = { path = "/home/andrew/code/paritytech/ink/core" }
+# FIXME: remove aj-runtime-types branch once https://github.com/paritytech/ink/pull/108 merged
+ink_core = { git = "https://github.com/paritytech/ink/", branch = "aj-runtime-types", package = "ink_core" }
 parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
 
 [dev-dependencies]
-node-runtime = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "node-runtime", default-features = false }
-srml-contract = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "srml-contract", default-features = false }
+node-runtime = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "node-runtime", features = ["std"] }
+srml-contract = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "srml-contract", features = ["core"] }
 quickcheck = "0.8"
 quickcheck_macros = "0.8"
 
 [features]
-default = [
-    "srml-contract/core",
-]
-test-env = ["std"]
+default = []
 std = [
     "ink_core/std",
-    "node-runtime/std",
-    "srml-contract/std",
 ]

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -18,12 +18,18 @@ categories = ["no-std", "embedded"]
 include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
-ink_core = { git = "https://github.com/paritytech/ink/", package = "ink_core" }
+# ink_core = { git = "https://github.com/paritytech/ink/", branch = "aj-runtime-types", package = "ink_core" }
+ink_core = { path = "/home/andrew/code/paritytech/ink/core" }
+parity-codec = { version = "3.2", default-features = false, features = ["derive"] }
+
+[dev-dependencies]
 node-runtime = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "node-runtime", default-features = false }
 srml-contract = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "srml-contract", default-features = false }
 # ignore duplicate wasm lang items
 sr-std = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "sr-std", default-features = false, features = ["no_global_allocator"] }
 sr-io = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "sr-io", default-features = false, features = ["no_oom", "no_panic_handler"] }
+quickcheck = "0.8"
+quickcheck_macros = "0.8"
 
 [features]
 default = [

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -25,9 +25,6 @@ parity-codec = { version = "3.2", default-features = false, features = ["derive"
 [dev-dependencies]
 node-runtime = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "node-runtime", default-features = false }
 srml-contract = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "srml-contract", default-features = false }
-# ignore duplicate wasm lang items
-sr-std = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "sr-std", default-features = false, features = ["no_global_allocator"] }
-sr-io = { git = "https://github.com/paritytech/substrate/", branch = "aj-ink-types", package = "sr-io", default-features = false, features = ["no_oom", "no_panic_handler"] }
 quickcheck = "0.8"
 quickcheck_macros = "0.8"
 

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # Node runtime types for `ink!`
 
-**NOTE:** This currently depends on a custom branch of `substrate`, with some extra trait implementations for some of the types. This will be updated when we merge those changes.
-
 Defines types for [ink!](https://github.com/paritytech/ink) smart contracts targeting [Substrate's `node-runtime`](https://github.com/paritytech/substrate/blob/master/node/runtime/src/lib.rs).
 
 Supplies an implementation of the ink `EnvTypes` trait:
@@ -19,5 +17,5 @@ pub trait EnvTypes {
 }
 ```
 
-See `ink!` [examples](https://github.com/paritytech/ink/tree/master/examples/lang) for usage.
+See `ink!` [example](https://github.com/paritytech/ink/tree/master/examples/lang/erc20) for usage.
 

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -19,15 +19,109 @@
 
 #![cfg_attr(not(any(test, feature = "test-env")), no_std)]
 
-use srml_contract;
-use node_runtime;
+use core::{
+    array::TryFromSliceError,
+    convert::TryFrom,
+};
+
+use parity_codec::{Encode, Decode};
 
 /// Contract environment types defined in substrate node-runtime
 pub enum NodeRuntimeTypes {}
 
+/// The default SRML address type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Encode, Decode)]
+pub struct AccountId([u8; 32]);
+
+impl From<[u8; 32]> for AccountId {
+    fn from(address: [u8; 32]) -> AccountId {
+        AccountId(address)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for AccountId {
+    type Error = TryFromSliceError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<AccountId, TryFromSliceError> {
+        let address = <[u8; 32]>::try_from(bytes)?;
+        Ok(AccountId(address))
+    }
+}
+
+/// The default SRML balance type.
+pub type Balance = u128;
+
+/// The default SRML hash type.
+#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, Encode, Decode)]
+pub struct Hash([u8; 32]);
+
+impl From<[u8; 32]> for Hash {
+    fn from(hash: [u8; 32]) -> Hash {
+        Hash(hash)
+    }
+}
+
+impl<'a> TryFrom<&'a [u8]> for Hash {
+    type Error = TryFromSliceError;
+
+    fn try_from(bytes: &'a [u8]) -> Result<Hash, TryFromSliceError> {
+        let hash = <[u8; 32]>::try_from(bytes)?;
+        Ok(Hash(hash))
+    }
+}
+
+/// The default SRML moment type.
+pub type Moment = u64;
+
 impl ink_core::env::EnvTypes for NodeRuntimeTypes {
-    type AccountId = srml_contract::AccountIdOf<node_runtime::Runtime>;
-    type Balance = srml_contract::BalanceOf<node_runtime::Runtime>;
-    type Hash = srml_contract::SeedOf<node_runtime::Runtime>;
-    type Moment = srml_contract::MomentOf<node_runtime::Runtime>;
+    type AccountId = AccountId;
+    type Balance = Balance;
+    type Hash = Hash;
+    type Moment = Moment;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+    use srml_contract::AccountIdOf;
+    use node_runtime::Runtime;
+    use parity_codec::{Encode, Decode};
+    use quickcheck_macros::quickcheck;
+
+    #[derive(Debug, Clone)]
+    struct ContractAccountId(AccountId);
+
+    impl quickcheck::Arbitrary for ContractAccountId {
+        fn arbitrary<G: quickcheck::Gen>(g: &mut G) -> Self {
+            let mut res = [0u8; core::mem::size_of::<Self>()];
+			g.fill_bytes(&mut res[..]);
+            ContractAccountId(AccountId(res)) 
+        }
+    }
+
+    #[quickcheck]
+    fn account_id(value: ContractAccountId) {
+        let contract_encoded = Encode::encode(&value.0);
+        let runtime_decoded: AccountIdOf<Runtime> = Decode::decode(&mut contract_encoded.as_slice())
+            .expect("Should be decodable into node_runtime type");
+        let runtime_encoded = Encode::encode(&runtime_decoded);
+        let contract_decoded = Decode::decode(&mut runtime_encoded.as_slice())
+            .expect("Should be decodable into contract env type");
+        assert_eq!(value.0, contract_decoded)
+    }
+
+    // #[test]
+    // pub fn balance() {
+    //     let x: <NodeRuntimeTypes as ink_core::env::EnvTypes>::Balance = ();
+    // }
+
+    // #[test]
+    // pub fn hash() {
+    //     let x: <NodeRuntimeTypes as ink_core::env::EnvTypes>::Hash = ();
+    // }
+
+    // #[test]
+    // pub fn moment() {
+    //     let x: <NodeRuntimeTypes as ink_core::env::EnvTypes>::Moment = ();
+    // }
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -17,7 +17,7 @@
 //! Definitions for environment types for contracts targeted at a
 //! substrate chain with the default `node-runtime` configuration.
 
-#![cfg_attr(not(any(test, feature = "test-env")), no_std)]
+#![cfg_attr(not(test), no_std)]
 
 use core::{
     array::TryFromSliceError,


### PR DESCRIPTION
*Duplicate of #1, which I orphaned by mistake.*

Using the `node-runtime` types directly resulted in a large wasm binary: e.g. for ERC20:

![image](https://user-images.githubusercontent.com/75586/59120358-1c317080-894d-11e9-9379-2064ce640a34.png)

This PR creates some local types which "mirror" the equivalent types in `node-runtime`. In order to verify that they are compatible, the tests perform an `encode -> decode -> encode` roundtrip with the runtime type.
