### PR TITLE
Use substrate Address/AccountId primitives

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -20,11 +20,10 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 [dependencies]
 ink_core = { git = "https://github.com/paritytech/ink/", package = "ink_core", default-features = false }
 frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system", default-features = false }
-#pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices", default-features = false }
-#pallet-timestamp = { git = "https://github.com/paritytech/substrate/", package = "pallet-timestamp",  default-features = false }
-#pallet-contract = { git = "https://github.com/paritytech/substrate/", package = "pallet-contracts",  default-features = false }
-#node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime", default-features = false }
+pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices", default-features = false }
 sp-core = { git = "https://github.com/paritytech/substrate/", package = "sp-core", default-features = false }
+sp-io = { git = "https://github.com/paritytech/substrate/", package = "sp-io", default-features = false, features = ["disable_panic_handler", "disable_oom", "disable_allocator"] }
+sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-runtime", default-features = false }
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
 
@@ -33,11 +32,8 @@ default = ["std"]
 std = [
     "ink_core/std",
     "frame-system/std",
-#    "pallet-indices/std",
-#    "pallet-timestamp/std",
-#    "pallet-contract/std",
+    "pallet-indices/std",
     "sp-core/std",
-#    "node-runtime/std",
 ]
 ink-generate-abi = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -19,23 +19,25 @@ include = ["/Cargo.toml", "src/**/*.rs", "/README.md", "/LICENSE"]
 
 [dependencies]
 ink_core = { git = "https://github.com/paritytech/ink/", package = "ink_core", default-features = false }
-
+frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system", default-features = false }
+#pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices", default-features = false }
+#pallet-timestamp = { git = "https://github.com/paritytech/substrate/", package = "pallet-timestamp",  default-features = false }
+#pallet-contract = { git = "https://github.com/paritytech/substrate/", package = "pallet-contracts",  default-features = false }
+#node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime", default-features = false }
+sp-core = { git = "https://github.com/paritytech/substrate/", package = "sp-core", default-features = false }
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
-
-[dev-dependencies]
-node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime", features = ["std"] }
-frame-system = { git = "https://github.com/paritytech/substrate/", package = "frame-system", features = ["std"] }
-pallet-timestamp = { git = "https://github.com/paritytech/substrate/", package = "pallet-timestamp", features = ["std"] }
-pallet-contract = { git = "https://github.com/paritytech/substrate/", package = "pallet-contracts", features = ["std"] }
-pallet-indices = { git = "https://github.com/paritytech/substrate/", package = "pallet-indices", features = ["std"] }
-quickcheck = "0.8"
-quickcheck_macros = "0.8"
 
 [features]
 default = ["std"]
 std = [
     "ink_core/std",
+    "frame-system/std",
+#    "pallet-indices/std",
+#    "pallet-timestamp/std",
+#    "pallet-contract/std",
+    "sp-core/std",
+#    "node-runtime/std",
 ]
 ink-generate-abi = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -37,6 +37,8 @@ std = [
     "frame-system/std",
     "pallet-indices/std",
     "sp-core/std",
+    "sp-io/std",
+    "sp-runtime/std",
 ]
 ink-generate-abi = [
     "std",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -27,6 +27,9 @@ sp-runtime = { git = "https://github.com/paritytech/substrate/", package = "sp-r
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
 
+[dev-dependencies]
+node-runtime = { git = "https://github.com/paritytech/substrate/", package = "node-runtime", features = ["std"] }
+
 [features]
 default = ["std"]
 std = [

--- a/README.md
+++ b/README.md
@@ -1,21 +1,8 @@
 # Node runtime types for `ink!`
 
-Defines types for [ink!](https://github.com/paritytech/ink) smart contracts targeting [Substrate's `node-runtime`](https://github.com/paritytech/substrate/blob/master/node/runtime/src/lib.rs).
+Defines types for [ink!](https://github.com/paritytech/ink) smart contracts targeting [Substrate's `node-runtime`](https://github.com/paritytech/substrate/blob/master/bin/node/runtime/src/lib.rs).
 
-Supplies an implementation of the ink `EnvTypes` trait:
+Supplies an implementation of the [ink! `EnvTypes` trait](https://github.com/paritytech/ink/blob/master/core/src/env/types.rs#L130).
 
-```
-pub trait EnvTypes {
-    /// The type of an address.
-    type AccountId: parity_codec::Codec + PartialEq + Eq;
-    /// The type of balances.
-    type Balance: parity_codec::Codec;
-    /// The type of hash.
-    type Hash: parity_codec::Codec;
-    /// The type of timestamps.
-    type Moment: parity_codec::Codec;
-}
-```
-
-See `ink!` [example](https://github.com/paritytech/ink/tree/master/examples/lang/erc20) for usage.
+See `ink!` [examples](./examples) for usage.
 

--- a/examples/calls/.cargo/config
+++ b/examples/calls/.cargo/config
@@ -1,4 +1,0 @@
-[target.wasm32-unknown-unknown]
-rustflags = [
-	"-C", "link-args=-z stack-size=65536 --import-memory"
-]

--- a/examples/calls/Cargo.toml
+++ b/examples/calls/Cargo.toml
@@ -9,6 +9,7 @@ ink_abi = { git = "https://github.com/paritytech/ink", package = "ink_abi", defa
 ink_primitives = { git = "https://github.com/paritytech/ink", package = "ink_primitives", default-features = false }
 ink_core = { git = "https://github.com/paritytech/ink", package = "ink_core", default-features = false }
 ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang", default-features = false }
+ink_prelude = { git = "https://github.com/paritytech/ink", package = "ink_prelude", default-features = false }
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }

--- a/examples/calls/Cargo.toml
+++ b/examples/calls/Cargo.toml
@@ -15,6 +15,9 @@ type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", de
 
 ink_types_node_runtime = { path = "../../", default-features = false }
 
+[dev-dependencies]
+sp-keyring = { git = "https://github.com/paritytech/substrate/", package = "sp-keyring", default-features = false }
+
 [lib]
 name = "calls"
 path = "lib.rs"
@@ -33,6 +36,7 @@ std = [
     "ink_primitives/std",
     "scale/std",
     "type-metadata/std",
+    "ink_types_node_runtime/std",
 ]
 test-env = [
     "std",

--- a/examples/calls/Cargo.toml
+++ b/examples/calls/Cargo.toml
@@ -12,11 +12,9 @@ ink_lang = { git = "https://github.com/paritytech/ink", package = "ink_lang", de
 
 scale = { package = "parity-scale-codec", version = "1.1", default-features = false, features = ["derive"] }
 type-metadata = { git = "https://github.com/type-metadata/type-metadata.git", default-features = false, features = ["derive"], optional = true }
+sp-keyring = { git = "https://github.com/paritytech/substrate/", package = "sp-keyring", optional = true }
 
 ink_types_node_runtime = { path = "../../", default-features = false }
-
-[dev-dependencies]
-sp-keyring = { git = "https://github.com/paritytech/substrate/", package = "sp-keyring", default-features = false }
 
 [lib]
 name = "calls"
@@ -37,6 +35,7 @@ std = [
     "scale/std",
     "type-metadata/std",
     "ink_types_node_runtime/std",
+    "sp-keyring",
 ]
 test-env = [
     "std",

--- a/examples/calls/lib.rs
+++ b/examples/calls/lib.rs
@@ -5,6 +5,8 @@ use ink_lang as ink;
 
 #[ink::contract(version = "0.1.0", env = NodeRuntimeTypes)]
 mod calls {
+    use ink_core::env;
+    use ink_prelude::*;
     use ink_types_node_runtime::{calls as runtime_calls, NodeRuntimeTypes};
 
     /// This simple dummy contract dispatches substrate runtime calls
@@ -18,8 +20,14 @@ mod calls {
         /// Dispatches a `transfer` call to the Balances srml module
         #[ink(message)]
         fn balance_transfer(&self, dest: AccountId, value: Balance) {
+            // create the Balances::transfer Call
             let transfer_call = runtime_calls::transfer_balance(dest, value);
-            let _ = self.env().invoke_runtime(&transfer_call);
+            // dispatch the call to the runtime
+            let result = self.env().invoke_runtime(&transfer_call);
+
+            // report result to console
+            // NOTE: println should only be used on a development chain)
+            env::println(&format!("Balance transfer invoke_runtime result {:?}", result));
         }
     }
 

--- a/examples/calls/lib.rs
+++ b/examples/calls/lib.rs
@@ -5,7 +5,7 @@ use ink_lang as ink;
 
 #[ink::contract(version = "0.1.0", env = NodeRuntimeTypes)]
 mod calls {
-    use ink_types_node_runtime::{calls as runtime_calls, AccountIndex, Call, NodeRuntimeTypes};
+    use ink_types_node_runtime::{calls as runtime_calls, NodeRuntimeTypes};
 
     /// This simple dummy contract dispatches substrate runtime calls
     #[ink(storage)]
@@ -18,10 +18,7 @@ mod calls {
         /// Dispatches a `transfer` call to the Balances srml module
         #[ink(message)]
         fn balance_transfer(&self, dest: AccountId, value: Balance) {
-            let transfer_call = Call::Balances(runtime_calls::Balances::<
-                NodeRuntimeTypes,
-                AccountIndex,
-            >::transfer(dest.into(), value));
+            let transfer_call = runtime_calls::transfer_balance(dest, value);
             let _ = self.env().invoke_runtime(&transfer_call);
         }
     }
@@ -29,11 +26,12 @@ mod calls {
     #[cfg(test)]
     mod tests {
         use super::*;
+        use sp_keyring::AccountKeyring;
 
         #[test]
         fn dispatches_balances_call() {
             let calls = Calls::new();
-            let alice = AccountId::from([0x0; 32]);
+            let alice = AccountId::from(AccountKeyring::Alice.to_account_id());
             // assert_eq!(calls.env().dispatched_calls().into_iter().count(), 0);
             calls.balance_transfer(alice, 10000);
             // assert_eq!(calls.env().dispatched_calls().into_iter().count(), 1);

--- a/examples/calls/lib.rs
+++ b/examples/calls/lib.rs
@@ -18,11 +18,10 @@ mod calls {
         /// Dispatches a `transfer` call to the Balances srml module
         #[ink(message)]
         fn balance_transfer(&self, dest: AccountId, value: Balance) {
-            let dest_addr = runtime_calls::Address::Id(dest);
             let transfer_call = Call::Balances(runtime_calls::Balances::<
                 NodeRuntimeTypes,
                 AccountIndex,
-            >::transfer(dest_addr, value));
+            >::transfer(dest.into(), value));
             let _ = self.env().invoke_runtime(&transfer_call);
         }
     }

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -38,7 +38,6 @@ where
 
 #[cfg(test)]
 mod tests {
-    use super::*;
     use crate::{calls, AccountIndex, Call, NodeRuntimeTypes};
 
     use node_runtime::{self, Runtime};

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -18,7 +18,24 @@ use ink_core::env::EnvTypes;
 use scale::{Codec, Decode, Encode};
 use pallet_indices::address::Address;
 use sp_runtime::traits::Member;
+use crate::{AccountId, AccountIndex, Balance, NodeRuntimeTypes};
 
+/// Default runtime Call type, a subset of the runtime Call module variants
+///
+/// The codec indices of the  modules *MUST* match those in the concrete runtime.
+#[derive(Encode, Decode)]
+#[cfg_attr(feature = "std", derive(Clone, PartialEq, Eq))]
+pub enum Call {
+    #[codec(index = "6")]
+    Balances(Balances<NodeRuntimeTypes, AccountIndex>),
+}
+
+impl From<Balances<NodeRuntimeTypes, AccountIndex>> for Call {
+    fn from(balances_call: Balances<NodeRuntimeTypes, AccountIndex>) -> Call {
+        Call::Balances(balances_call)
+    }
+}
+/// Generic Balance Call, could be used with other runtimes
 #[derive(Encode, Decode, Clone, PartialEq, Eq)]
 pub enum Balances<T, AccountIndex>
 where
@@ -36,9 +53,15 @@ where
     ),
 }
 
+/// Construct a `Balances::transfer` call
+pub fn transfer_balance(account: AccountId, balance: Balance) -> Call {
+    Balances::<NodeRuntimeTypes, AccountIndex>::transfer(account.into(), balance).into()
+}
+
 #[cfg(test)]
 mod tests {
-    use crate::{calls, AccountIndex, Call, NodeRuntimeTypes};
+    use crate::{calls, AccountIndex, NodeRuntimeTypes};
+    use super::Call;
 
     use node_runtime::{self, Runtime};
     use pallet_indices::address;

--- a/src/calls.rs
+++ b/src/calls.rs
@@ -14,103 +14,23 @@
 // You should have received a copy of the GNU General Public License
 // along with ink!.  If not, see <http://www.gnu.org/licenses/>.
 
-use core::convert::TryInto;
 use ink_core::env::EnvTypes;
-use scale::{Decode, Encode, Error, Input, Output};
+use scale::{Codec, Decode, Encode};
+use pallet_indices::address::Address;
+use sp_runtime::traits::Member;
 
-#[cfg_attr(feature = "std", derive(Clone, PartialEq, Eq))]
-pub enum Address<T: EnvTypes, AccountIndex> {
-    Id(T::AccountId),
-    Index(AccountIndex),
-}
-
-/// Returns `b` if `b` is greater than `a` and otherwise `None`.
-fn greater_than_or_err<T: PartialOrd>(a: T, b: T) -> Result<T, Error> {
-    if a < b {
-        Ok(b)
-    } else {
-        Err("Invalid range".into())
-    }
-}
-
-/// Decode implementation copied over from Substrate `Address` that can be found [here](substrate-address).
-///
-/// # Note
-/// This implementation MUST be kept in sync with substrate, tests below will ensure that.
-///
-/// [substrate-address]: https://github.com/paritytech/substrate/blob/ec62d24c602912f07bbc416711376d9b8e5782c5/srml/indices/src/address.rs#L61
-impl<T, AccountIndex> Decode for Address<T, AccountIndex>
+#[derive(Encode, Decode, Clone, PartialEq, Eq)]
+pub enum Balances<T, AccountIndex>
 where
     T: EnvTypes,
-    AccountIndex: Decode + From<u32> + PartialOrd + Copy + Clone,
+    T::AccountId: Member + Codec,
+    AccountIndex: Member + Codec,
 {
-    fn decode<I: Input>(input: &mut I) -> Result<Self, Error> {
-        Ok(match input.read_byte()? {
-            x @ 0x00..=0xef => Address::Index(AccountIndex::from(x as u32)),
-            0xfc => Address::Index(AccountIndex::from(greater_than_or_err(
-                0xef,
-                u16::decode(input)?,
-            )? as u32)),
-            0xfd => Address::Index(AccountIndex::from(greater_than_or_err(
-                0xffff,
-                u32::decode(input)?,
-            )?)),
-            0xfe => Address::Index(greater_than_or_err(
-                0xffffffffu32.into(),
-                Decode::decode(input)?,
-            )?),
-            0xff => Address::Id(Decode::decode(input)?),
-            _ => return Err("Invalid address variant".into()),
-        })
-    }
-}
-
-/// Encode implementation copied over from Substrate `Address` that can be found [here](substrate-address).
-///
-/// # Note
-/// This implementation MUST be kept in sync with substrate, tests below will ensure that.
-///
-/// [substrate-address]: https://github.com/paritytech/substrate/blob/ec62d24c602912f07bbc416711376d9b8e5782c5/srml/indices/src/address.rs#L83
-impl<T, AccountIndex> Encode for Address<T, AccountIndex>
-where
-    T: EnvTypes,
-    AccountIndex: Encode + TryInto<u32> + Copy + Clone,
-{
-    fn encode_to<O: Output>(&self, dest: &mut O) {
-        match *self {
-            Address::Id(ref i) => {
-                dest.push_byte(255);
-                dest.push(i);
-            }
-            Address::Index(i) => {
-                let maybe_u32: Result<u32, _> = i.try_into();
-                if let Ok(x) = maybe_u32 {
-                    if x > 0xffff {
-                        dest.push_byte(253);
-                        dest.push(&x);
-                    } else if x >= 0xf0 {
-                        dest.push_byte(252);
-                        dest.push(&(x as u16));
-                    } else {
-                        dest.push_byte(x as u8);
-                    }
-                } else {
-                    dest.push_byte(254);
-                    dest.push(&i);
-                }
-            }
-        }
-    }
-}
-
-#[derive(Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Clone, PartialEq, Eq))]
-pub enum Balances<T: EnvTypes, AccountIndex> {
     #[allow(non_camel_case_types)]
-    transfer(Address<T, AccountIndex>, #[codec(compact)] T::Balance),
+    transfer(Address<T::AccountId, AccountIndex>, #[codec(compact)] T::Balance),
     #[allow(non_camel_case_types)]
     set_balance(
-        Address<T, AccountIndex>,
+        Address<T::AccountId, AccountIndex>,
         #[codec(compact)] T::Balance,
         #[codec(compact)] T::Balance,
     ),
@@ -125,52 +45,6 @@ mod tests {
     use pallet_indices::address;
     use scale::{Decode, Encode};
 
-    #[test]
-    fn account_index_serialization() {
-        let account_index = 0u32;
-
-        let ink_address: Address<NodeRuntimeTypes, u32> = Address::Index(account_index.into());
-        let pallet_address: address::Address<[u8; 32], u32> =
-            address::Address::Index(account_index);
-
-        let ink_encoded = ink_address.encode();
-        let pallet_encoded = pallet_address.encode();
-
-        assert_eq!(pallet_encoded, ink_encoded);
-
-        let srml_decoded: address::Address<[u8; 32], u32> =
-            Decode::decode(&mut ink_encoded.as_slice())
-                .expect("Account Index decodes to srml Address");
-        let srml_encoded = srml_decoded.encode();
-        let ink_decoded: Address<NodeRuntimeTypes, u32> =
-            Decode::decode(&mut srml_encoded.as_slice())
-                .expect("Account Index decodes back to ink type");
-
-        assert!(ink_address == ink_decoded);
-    }
-
-    #[test]
-    fn account_id_serialization() {
-        let account_id = [0u8; 32];
-
-        let ink_address = Address::Id(account_id.into());
-        let srml_address: address::Address<[u8; 32], u32> = address::Address::Id(account_id);
-
-        let ink_encoded = ink_address.encode();
-        let srml_encoded = srml_address.encode();
-
-        assert_eq!(srml_encoded, ink_encoded);
-
-        let srml_decoded: address::Address<[u8; 32], u32> =
-            Decode::decode(&mut ink_encoded.as_slice())
-                .expect("Account Id decodes to srml Address");
-        let srml_encoded = srml_decoded.encode();
-        let ink_decoded: Address<NodeRuntimeTypes, u32> =
-            Decode::decode(&mut srml_encoded.as_slice())
-                .expect("Account Id decodes decodes back to ink type");
-
-        assert!(ink_address == ink_decoded);
-    }
 
     #[test]
     fn call_balance_transfer() {

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,6 +22,7 @@
 use core::{array::TryFromSliceError, convert::TryFrom};
 use ink_core::env::Clear;
 use scale::{Decode, Encode};
+use sp_core::crypto::AccountId32 as AccountId;
 
 pub mod calls;
 
@@ -29,26 +30,6 @@ pub mod calls;
 #[cfg_attr(feature = "std", derive(Clone, PartialEq, Eq))]
 #[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
 pub enum NodeRuntimeTypes {}
-
-/// The default SRML address type.
-#[derive(Debug, Copy, Clone, PartialEq, Eq, Hash, PartialOrd, Ord, Encode, Decode)]
-#[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
-pub struct AccountId([u8; 32]);
-
-impl From<[u8; 32]> for AccountId {
-    fn from(address: [u8; 32]) -> AccountId {
-        AccountId(address)
-    }
-}
-
-impl<'a> TryFrom<&'a [u8]> for AccountId {
-    type Error = TryFromSliceError;
-
-    fn try_from(bytes: &'a [u8]) -> Result<AccountId, TryFromSliceError> {
-        let address = <[u8; 32]>::try_from(bytes)?;
-        Ok(AccountId(address))
-    }
-}
 
 /// The default SRML balance type.
 pub type Balance = u128;

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -23,6 +23,7 @@ use core::{array::TryFromSliceError, convert::TryFrom};
 use ink_core::env::Clear;
 use scale::{Decode, Encode};
 use sp_core::crypto::AccountId32;
+#[cfg(feature = "ink-generate-abi")]
 use type_metadata::{HasTypeId, HasTypeDef, Metadata, MetaType, TypeId, TypeDef, TypeIdArray};
 
 pub mod calls;
@@ -111,25 +112,11 @@ pub type AccountIndex = u32;
 /// The default timestamp type.
 pub type Timestamp = u64;
 
-/// The default SRML call type.
-#[derive(Encode, Decode)]
-#[cfg_attr(feature = "std", derive(Clone, PartialEq, Eq))]
-pub enum Call {
-    #[codec(index = "6")]
-    Balances(calls::Balances<NodeRuntimeTypes, AccountIndex>),
-}
-
-impl From<calls::Balances<NodeRuntimeTypes, AccountIndex>> for Call {
-    fn from(balances_call: calls::Balances<NodeRuntimeTypes, AccountIndex>) -> Call {
-        Call::Balances(balances_call)
-    }
-}
-
 impl ink_core::env::EnvTypes for NodeRuntimeTypes {
     type AccountId = AccountId;
     type Balance = Balance;
     type Hash = Hash;
     type Timestamp = Timestamp;
     type BlockNumber = BlockNumber;
-    type Call = Call;
+    type Call = calls::Call;
 }

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -22,14 +22,38 @@
 use core::{array::TryFromSliceError, convert::TryFrom};
 use ink_core::env::Clear;
 use scale::{Decode, Encode};
-use sp_core::crypto::AccountId32 as AccountId;
+use sp_core::crypto::AccountId32;
+use type_metadata::{HasTypeId, HasTypeDef, Metadata, MetaType, TypeId, TypeDef, TypeIdArray};
 
 pub mod calls;
 
 /// Contract environment types defined in substrate node-runtime
-#[cfg_attr(feature = "ink-generate-abi", derive(type_metadata::Metadata))]
+#[cfg_attr(feature = "ink-generate-abi", derive(Metadata))]
 #[derive(Clone, Debug, PartialEq, Eq)]
 pub enum NodeRuntimeTypes {}
+
+#[derive(Clone, Debug, PartialEq, Eq, PartialOrd, Ord, Encode, Decode)]
+pub struct AccountId (AccountId32);
+
+impl From<AccountId32> for AccountId {
+    fn from(account: AccountId32) -> Self {
+        AccountId(account)
+    }
+}
+
+#[cfg(feature = "ink-generate-abi")]
+impl HasTypeId for AccountId {
+    fn type_id() -> TypeId {
+        TypeIdArray::new(32, MetaType::new::<u8>()).into()
+    }
+}
+
+#[cfg(feature = "ink-generate-abi")]
+impl HasTypeDef for AccountId {
+    fn type_def() -> TypeDef {
+        TypeDef::builtin()
+    }
+}
 
 /// The default SRML balance type.
 pub type Balance = u128;


### PR DESCRIPTION
With recent `cargo-contract` optimizations, we can now use substrate types directly without excessive Wasm size bloat. 

This PR replaces the copied `Address`  and `AccountId` types with a dependency on the actual substrate type.

## todo

- [x] fix generate-metadata
- [x] test on chain

rel #7 