### PR TITLE
Remove proc macro hygiene feature usage

### DIFF
--- a/examples/calls/lib.rs
+++ b/examples/calls/lib.rs
@@ -1,4 +1,3 @@
-#![feature(proc_macro_hygiene)]
 #![cfg_attr(not(feature = "std"), no_std)]
 
 use ink_lang as ink;


### PR DESCRIPTION
No longer needed feature. Can be removed.